### PR TITLE
feat: ui improvements & fixes

### DIFF
--- a/app/src/main/java/com/denser/june/MainActivity.kt
+++ b/app/src/main/java/com/denser/june/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.SystemBarStyle
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.Image
@@ -30,12 +31,17 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import com.denser.june.core.domain.preferences.PrivacyPreferences
+import com.denser.june.core.domain.preferences.ThemePreferences
+import com.denser.june.core.domain.preferences.FontPreferences
+import com.denser.june.core.domain.model.AppTheme
+import com.denser.june.core.domain.model.getAppThemeFlow
 import com.denser.june.core.domain.model.enums.LockType
 import com.denser.june.presentation.components.PinLockScreen
 import com.denser.june.core.utils.SecurityUtils
 import com.denser.june.presentation.JuneApp
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.android.inject
 import com.denser.june.core.R
 import androidx.core.graphics.drawable.toDrawable
@@ -50,6 +56,8 @@ enum class LockState {
 class MainActivity : FragmentActivity() {
 
     private val privacyPreferences: PrivacyPreferences by inject()
+    private val themePrefs: ThemePreferences by inject()
+    private val fontPrefs: FontPreferences by inject()
     private var lockState by mutableStateOf(LockState.LOADING)
 
     private var isPinError by mutableStateOf(false)
@@ -59,6 +67,10 @@ class MainActivity : FragmentActivity() {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val initialAppTheme = runBlocking {
+            themePrefs.getAppThemeFlow(fontPrefs).first()
+        }
 
         splashScreen.setKeepOnScreenCondition { lockState == LockState.LOADING }
 
@@ -75,7 +87,6 @@ class MainActivity : FragmentActivity() {
                         lockState = LockState.LOCKED_BIOMETRIC
                         checkBiometricAndAuthenticate()
                     }
-
                     LockType.PIN -> {
                         if (storedPinHash != null) {
                             lockState = LockState.LOCKED_PIN
@@ -109,7 +120,7 @@ class MainActivity : FragmentActivity() {
             MaterialTheme(colorScheme = systemColorScheme) {
                 when (lockState) {
                     LockState.UNLOCKED -> {
-                        JuneApp()
+                        JuneApp(initialAppTheme = initialAppTheme)
                     }
 
                     LockState.LOCKED_PIN -> {

--- a/app/src/main/java/com/denser/june/MainVM.kt
+++ b/app/src/main/java/com/denser/june/MainVM.kt
@@ -6,6 +6,7 @@ import com.denser.june.core.domain.preferences.PrivacyPreferences
 import com.denser.june.core.domain.preferences.ThemePreferences
 import com.denser.june.core.domain.preferences.FontPreferences
 import com.denser.june.core.domain.model.AppTheme
+import com.denser.june.core.domain.model.getAppThemeFlow
 import com.denser.june.core.domain.preferences.SyncPreferences
 import com.denser.june.core.domain.sync.SyncManager
 import com.denser.june.core.domain.sync.SyncStatus
@@ -23,6 +24,7 @@ data class AppState(
 )
 
 class MainVM(
+    initialAppTheme: AppTheme,
     themePrefs: ThemePreferences,
     privacyPrefs: PrivacyPreferences,
     fontPrefs: FontPreferences,
@@ -30,43 +32,24 @@ class MainVM(
     syncPrefs: SyncPreferences
 ) : ViewModel() {
 
-    private val themeFlow = combine(
-        themePrefs.getSeedColorFlow(),
-        themePrefs.getThemeMode(),
-        themePrefs.getAmoledPrefFlow(),
-        themePrefs.getPaletteStyle(),
-        themePrefs.getMaterialYouFlow()
-    ) { seed, themeMode, amoled, style, matYou ->
-        AppTheme(
-            seedColor = seed,
-            themeMode = themeMode,
-            withAmoled = amoled,
-            style = style,
-            materialTheme = matYou
-        )
-    }
-
     val state = combine(
-        themeFlow,
-        fontPrefs.getAppFont(),
+        themePrefs.getAppThemeFlow(fontPrefs),
         privacyPrefs.getAppLockFlow(),
         syncManager.status,
         syncPrefs.getSyncEnabled(),
         privacyPrefs.getIsInternetAllowedFlow()
-    ) { args: Array<Any?> ->
-        val baseTheme = args[0] as AppTheme
-
+    ) { appTheme, isAppLockEnabled, syncStatus, isSyncEnabled, isInternetAllowed ->
         AppState(
-            appTheme = baseTheme.copy(appFont = args[1] as String),
-            isAppLockEnabled = args[2] as Boolean,
+            appTheme = appTheme,
+            isAppLockEnabled = isAppLockEnabled,
             isLoading = false,
-            syncStatus = args[3] as SyncStatus,
-            isSyncEnabled = args[4] as Boolean,
-            isInternetAllowed = args[5] as Boolean
+            syncStatus = syncStatus,
+            isSyncEnabled = isSyncEnabled,
+            isInternetAllowed = isInternetAllowed
         )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
-        initialValue = AppState()
+        initialValue = AppState(appTheme = initialAppTheme)
     )
 }

--- a/app/src/main/java/com/denser/june/di/JuneModules.kt
+++ b/app/src/main/java/com/denser/june/di/JuneModules.kt
@@ -2,6 +2,7 @@ package com.denser.june.di
 
 import com.denser.june.MainVM
 import com.denser.june.core.di.coreModule
+import com.denser.june.core.domain.model.AppTheme
 import com.denser.june.presentation.navigation.AppNavigator
 import com.denser.june.presentation.navigation.JuneNavigator
 import com.denser.june.presentation.screens.home.journals.JournalsVM
@@ -14,6 +15,7 @@ import com.denser.june.presentation.screens.settings.screens.sync.SyncVM
 import com.denser.june.presentation.screens.settings.screens.trash.BinVM
 import com.denser.june.presentation.screens.settings.screens.reminder.ReminderVM
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -21,7 +23,12 @@ import org.koin.dsl.module
 val juneModules = module {
     includes(coreModule)
 
-    viewModelOf(::MainVM)
+    viewModel { params ->
+        MainVM(
+            initialAppTheme = params.getOrNull() ?: AppTheme(),
+            get(), get(), get(), get(), get()
+        )
+    }
     viewModelOf(::SettingsVM)
     viewModelOf(::EditorVM)
     viewModelOf(::JournalsVM)

--- a/app/src/main/java/com/denser/june/presentation/JuneApp.kt
+++ b/app/src/main/java/com/denser/june/presentation/JuneApp.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.denser.june.MainVM
+import com.denser.june.core.domain.model.AppTheme
 import com.denser.june.presentation.navigation.AppNavigator
 import com.denser.june.presentation.navigation.JuneNavHost
 import com.denser.june.presentation.navigation.NavigationIntent
@@ -18,10 +19,11 @@ import com.denser.june.presentation.theme.LocalAppTheme
 import com.denser.june.presentation.theme.LocalInternetAllowed
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @Composable
-fun JuneApp() {
-    val mainVM: MainVM = koinViewModel()
+fun JuneApp(initialAppTheme: AppTheme) {
+    val mainVM: MainVM = koinViewModel(parameters = { parametersOf(initialAppTheme) })
     val appState by mainVM.state.collectAsStateWithLifecycle()
 
     val navigator = koinInject<AppNavigator>()
@@ -33,7 +35,6 @@ fun JuneApp() {
                 is NavigationIntent.NavigateBack -> {
                     navController.navigateUp()
                 }
-
                 is NavigationIntent.NavigateTo -> {
                     navController.navigate(intent.route) {
                         intent.popUpToRoute?.let { popUpRoute ->

--- a/app/src/main/java/com/denser/june/presentation/components/JuneTopAppBar.kt
+++ b/app/src/main/java/com/denser/june/presentation/components/JuneTopAppBar.kt
@@ -2,6 +2,7 @@ package com.denser.june.presentation.components
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -28,10 +29,10 @@ fun JuneTopAppBar(
         scrolledContainerColor = MaterialTheme.colorScheme.surface
     ),
     scrollBehavior: TopAppBarScrollBehavior? = null,
-    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets.add(
+        WindowInsets(left = 8.dp, right = 8.dp)
+    ),
 ) {
-    val globalModifier = modifier.padding(horizontal = 8.dp)
-
     when (type) {
         JuneAppBarType.Small -> {
             TopAppBar(
@@ -41,7 +42,7 @@ fun JuneTopAppBar(
                 colors = colors,
                 scrollBehavior = scrollBehavior,
                 windowInsets = windowInsets,
-                modifier = globalModifier
+                modifier = modifier
             )
         }
 
@@ -53,7 +54,7 @@ fun JuneTopAppBar(
                 colors = colors,
                 scrollBehavior = scrollBehavior,
                 windowInsets = windowInsets,
-                modifier = globalModifier
+                modifier = modifier
             )
         }
 
@@ -65,7 +66,7 @@ fun JuneTopAppBar(
                 colors = colors,
                 scrollBehavior = scrollBehavior,
                 windowInsets = windowInsets,
-                modifier = globalModifier
+                modifier = modifier
             )
         }
 
@@ -77,7 +78,7 @@ fun JuneTopAppBar(
                 colors = colors,
                 scrollBehavior = scrollBehavior,
                 windowInsets = windowInsets,
-                modifier = globalModifier
+                modifier = modifier
             )
         }
     }

--- a/app/src/main/java/com/denser/june/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/home/HomeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -15,7 +16,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.denser.june.presentation.navigation.AppNavigator
 import com.denser.june.presentation.navigation.Route
 import com.denser.june.core.domain.preferences.JournalPreferences
-import com.denser.june.core.domain.model.enums.TimeFormat
 import com.denser.june.presentation.components.JuneAppBarType
 import com.denser.june.presentation.components.JuneTopAppBar
 import com.denser.june.presentation.screens.home.components.HomeBottomBar
@@ -41,7 +41,9 @@ enum class HomeTab(val label: String, val iconRes: Int, val filledIconRes: Int) 
 @Composable
 fun HomeScreen() {
     val navigator = koinInject<AppNavigator>()
-    val mainVM: MainVM = koinViewModel()
+    val mainVM: MainVM = koinViewModel(
+        viewModelStoreOwner = LocalContext.current as androidx.activity.ComponentActivity
+    )
     val appState by mainVM.state.collectAsStateWithLifecycle()
     val journalPrefs = koinInject<JournalPreferences>()
     val isAutoTimeEnabled by journalPrefs.isAutoTimeEnabled().collectAsStateWithLifecycle(initialValue = false)
@@ -114,7 +116,7 @@ fun HomeScreen() {
                 state = pagerState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(innerPadding)
+                    .padding(top = innerPadding.calculateTopPadding())
             ) { page ->
                 when (HomeTab.entries[page]) {
                     HomeTab.Journals -> JournalsPage(isSelected = pagerState.currentPage == 0)

--- a/app/src/main/java/com/denser/june/presentation/screens/home/timeline/components/TimelineJournalTab.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/home/timeline/components/TimelineJournalTab.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -96,12 +95,11 @@ fun TimelineJournalTile(
             Column(
                 modifier = Modifier.weight(1f)
             ) {
-                val titleText = journal.title.ifBlank { "Untitled" }
-
                 Text(
-                    text = titleText,
+                    text = journal.title,
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 1,
+                    minLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -114,11 +112,6 @@ fun TimelineJournalTile(
                         show = true,
                         icon = if (journal.cloudId != null) R.drawable.cloud_24px else R.drawable.devices_24px,
                         label = if (journal.cloudId != null) "Cloud" else "Local"
-                    )
-                    JuneBadge(
-                        show = wordCount > 0,
-                        icon = R.drawable.article_24px,
-                        label = "$wordCount ${if (wordCount == 1) "word" else "words"}"
                     )
                     JuneBadge(
                         show = mediaCount > 0,

--- a/app/src/main/java/com/denser/june/presentation/screens/home/timeline/components/TimelineMapTab.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/home/timeline/components/TimelineMapTab.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -115,7 +116,11 @@ fun TimelineMapTab(
 
     val primaryColor = MaterialTheme.colorScheme.primary.toArgb()
     val onPrimaryColor = MaterialTheme.colorScheme.onPrimary.toArgb()
-    val mutedLineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.28f).toArgb()
+    val mutedLineColor = if (isDarkMap) {
+        Color.White.copy(alpha = 0.3f).toArgb()
+    } else {
+        Color.Black.copy(alpha = 0.3f).toArgb()
+    }
 
     val styleUrl by produceState(initialValue = "", mapStyleProvider, isDarkMap) {
         value = MapProviderUtils.getStyleUrl(mapStyleProvider, isDarkMap)
@@ -222,7 +227,7 @@ fun TimelineMapTab(
         if (isInternetAllowed) {
             MapViewLifecycleEffect(mapView)
 
-            LaunchedEffect(styleUrl) {
+            LaunchedEffect(styleUrl, sortedPoints) {
                 if (styleUrl.isBlank()) return@LaunchedEffect
                 mapView.getMapAsync { mapboxMap ->
                     mapboxMap.uiSettings.isAttributionEnabled = false
@@ -242,15 +247,10 @@ fun TimelineMapTab(
             Column(
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .padding(start = 16.dp, top = 12.dp),
+                    .padding(16.dp),
                 horizontalAlignment = Alignment.Start,
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                MapAttributions(
-                    provider = mapStyleProvider,
-                    isDarkMode = isDarkMap
-                )
-
                 val currentJournal = sortedPoints.getOrNull(selectedIndex)
                 val dayText = remember(currentJournal) { currentJournal?.dateTime?.toDayOfMonth() ?: "" }
                 val monthText = remember(currentJournal) { currentJournal?.dateTime?.toShortMonth()?.uppercase() ?: "" }
@@ -271,7 +271,7 @@ fun TimelineMapTab(
             Column(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 36.dp, end = 16.dp),
+                    .padding(16.dp),
                 horizontalAlignment = Alignment.End,
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
@@ -280,6 +280,17 @@ fun TimelineMapTab(
                     isDarkMode = isDarkMap,
                     onToggleDarkMode = { isDarkMap = !isDarkMap },
                     onToggleFullscreen = { viewModel.setCalendarExpanded(isMapExpanded) }
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 16.dp, bottom = 16.dp)
+            ) {
+                MapAttributions(
+                    provider = mapStyleProvider,
+                    isDarkMode = isDarkMap
                 )
             }
         } else {

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/screens/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/screens/AppearanceSettingsScreen.kt
@@ -70,29 +70,56 @@ fun AppearanceSettingsScreen() {
         }
 
         CompositionLocalProvider(LocalSettingsTriggers provides triggers) {
+            val appearanceTiles = SettingsTileRegistry.getTilesForCategory("Appearance").associateBy { it.key }
+
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
             ) {
-                item {
-                    SettingSection {
-                        val appearanceTiles = SettingsTileRegistry.getTilesForCategory("Appearance")
-                        appearanceTiles.forEach { tile ->
-                            if (tile.key == "SEED_COLOR") {
-                                AnimatedVisibility(
-                                    visible = !state.appTheme.materialTheme,
-                                    enter = expandVertically(),
-                                    exit = shrinkVertically()
-                                ) {
+                val themeGroup = listOfNotNull(
+                    appearanceTiles["APP_THEME"],
+                    appearanceTiles["AMOLED"]
+                )
+                if (themeGroup.isNotEmpty()) {
+                    item {
+                        SettingSection {
+                            themeGroup.forEach { it.content() }
+                        }
+                    }
+                }
+
+                val colorGroupKeys = listOf("MATERIAL_THEME", "SEED_COLOR", "PALETTE_SELECTION")
+                val colorGroup = colorGroupKeys.mapNotNull { appearanceTiles[it] }
+                if (colorGroup.isNotEmpty()) {
+                    item {
+                        SettingSection {
+                            colorGroup.forEach { tile ->
+                                if (tile.key == "SEED_COLOR") {
+                                    AnimatedVisibility(
+                                        visible = !state.appTheme.materialTheme,
+                                        enter = expandVertically(),
+                                        exit = shrinkVertically()
+                                    ) {
+                                        tile.content()
+                                    }
+                                } else {
                                     tile.content()
                                 }
-                            } else {
-                                tile.content()
                             }
                         }
                     }
                 }
+
+                val fontTile = appearanceTiles["APP_FONT"]
+                if (fontTile != null) {
+                    item {
+                        SettingSection {
+                            fontTile.content()
+                        }
+                    }
+                }
+
                 item {
                     Spacer(modifier = Modifier.height(32.dp))
                 }

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/screens/GeneralSettingsScreen.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/screens/GeneralSettingsScreen.kt
@@ -60,19 +60,56 @@ fun GeneralSettingsScreen() {
         }
 
         CompositionLocalProvider(LocalSettingsTriggers provides triggers) {
+            val generalTiles = SettingsTileRegistry.getTilesForCategory("General").associateBy { it.key }
+
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
             ) {
-                item {
-                    SettingSection {
-                        val generalTiles = SettingsTileRegistry.getTilesForCategory("General")
-                        generalTiles.forEach { tile ->
-                            tile.content()
+                val timeGroup = listOfNotNull(
+                    generalTiles["START_OF_WEEK"],
+                    generalTiles["TIME_FORMAT"],
+                    generalTiles["INCLUDE_TIME"]
+                )
+                if (timeGroup.isNotEmpty()) {
+                    item {
+                        SettingSection {
+                            timeGroup.forEach { it.content() }
                         }
                     }
                 }
+
+                val editorGroup = listOfNotNull(
+                    generalTiles["REMINDERS"],
+                    generalTiles["MARKDOWN_EDITOR"]
+                )
+                if (editorGroup.isNotEmpty()) {
+                    item {
+                        SettingSection {
+                            editorGroup.forEach { it.content() }
+                        }
+                    }
+                }
+
+                val mapTile = generalTiles["MAP_SETTINGS"]
+                if (mapTile != null) {
+                    item {
+                        SettingSection {
+                            mapTile.content()
+                        }
+                    }
+                }
+
+                val deleteTile = generalTiles["DELETE_ALL_JOURNALS"]
+                if (deleteTile != null) {
+                    item {
+                        SettingSection {
+                            deleteTile.content()
+                        }
+                    }
+                }
+
                 item {
                     Spacer(modifier = Modifier.height(32.dp))
                 }

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/tiles/DeleteAllJournalsTile.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/tiles/DeleteAllJournalsTile.kt
@@ -18,7 +18,7 @@ fun DeleteAllJournalsTile() {
             Icon(
                 painter = painterResource(R.drawable.warning_24px),
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.secondary
+                tint = MaterialTheme.colorScheme.error
             )
         },
         onClick = { triggers.onDeleteAllJournals() }

--- a/app/src/main/java/com/denser/june/presentation/theme/JuneTheme.kt
+++ b/app/src/main/java/com/denser/june/presentation/theme/JuneTheme.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
@@ -37,11 +38,12 @@ fun JuneTheme(
 
     val view = LocalView.current
     if (!view.isInEditMode) {
-        androidx.compose.runtime.SideEffect {
+        SideEffect {
             val window = (view.context as android.app.Activity).window
             val insetsController = WindowCompat.getInsetsController(window, view)
 
             insetsController.isAppearanceLightStatusBars = !isDarkMode
+            insetsController.isAppearanceLightNavigationBars = !isDarkMode
         }
     }
     DynamicMaterialTheme(

--- a/app/src/main/java/com/denser/june/presentation/utils/TimelineMapUtils.kt
+++ b/app/src/main/java/com/denser/june/presentation/utils/TimelineMapUtils.kt
@@ -16,6 +16,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.sqrt
 
 data class LocationGroup(
     val location: JournalLocation,
@@ -93,10 +94,22 @@ object TimelineMapUtils {
     fun createArchedPoints(start: LatLng, end: LatLng, segments: Int = 60): List<LatLng> {
         val latDiff = end.latitude - start.latitude
         val lngDiff = end.longitude - start.longitude
-        val distance = Math.sqrt(latDiff * latDiff + lngDiff * lngDiff).coerceAtLeast(1e-9)
+        val distance = sqrt(latDiff * latDiff + lngDiff * lngDiff).coerceAtLeast(1e-9)
         val archHeight = distance * 0.15
-        val controlLat = (start.latitude + end.latitude) / 2.0 + (-lngDiff / distance) * archHeight
-        val controlLng = (start.longitude + end.longitude) / 2.0 + (latDiff / distance) * archHeight
+        
+        val offsetLat = (-lngDiff / distance) * archHeight
+        val offsetLng = (latDiff / distance) * archHeight
+
+        val shouldInvert = if (abs(offsetLat) > 1e-9) {
+            offsetLat < 0
+        } else {
+            offsetLng < 0
+        }
+        
+        val factor = if (shouldInvert) -1.0 else 1.0
+        val controlLat = (start.latitude + end.latitude) / 2.0 + offsetLat * factor
+        val controlLng = (start.longitude + end.longitude) / 2.0 + offsetLng * factor
+
         return (0..segments).map { i ->
             val t = i.toDouble() / segments
             val u = 1.0 - t

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.June" parent="android:Theme.Material.NoActionBar"/>
+    <style name="Theme.June" parent="Theme.Material3.Dark.NoActionBar"/>
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">?android:attr/colorBackground</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.June" parent="android:Theme.Material.Light.NoActionBar"/>
+    <style name="Theme.June" parent="Theme.Material3.Light.NoActionBar"/>
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">?android:attr/colorBackground</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>

--- a/core/src/main/java/com/denser/june/core/domain/model/AppTheme.kt
+++ b/core/src/main/java/com/denser/june/core/domain/model/AppTheme.kt
@@ -1,7 +1,11 @@
 package com.denser.june.core.domain.model
 
 import com.denser.june.core.domain.model.enums.ThemeMode
+import com.denser.june.core.domain.preferences.FontPreferences
+import com.denser.june.core.domain.preferences.ThemePreferences
 import com.materialkolor.PaletteStyle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 
 data class AppTheme(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
@@ -11,3 +15,23 @@ data class AppTheme(
     val materialTheme: Boolean = false,
     val appFont: String = "Google Sans Flex",
 )
+
+fun ThemePreferences.getAppThemeFlow(fontPrefs: FontPreferences): Flow<AppTheme> {
+    return combine(
+        getSeedColorFlow(),
+        getThemeMode(),
+        getAmoledPrefFlow(),
+        getPaletteStyle(),
+        getMaterialYouFlow()
+    ) { seed, themeMode, amoled, style, matYou ->
+        AppTheme(
+            seedColor = seed,
+            themeMode = themeMode,
+            withAmoled = amoled,
+            style = style,
+            materialTheme = matYou
+        )
+    }.combine(fontPrefs.getAppFont()) { theme, font ->
+        theme.copy(appFont = font)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ jsonPath = "3.0.0"
 emojipicker = "1.6.0"
 biometric = "1.2.0-alpha05"
 googleFonts = "1.11.2"
-hyphen = "0.5.0-alpha04"
+hyphen = "0.5.0-alpha05"
 
 [libraries]
 # Core


### PR DESCRIPTION
## Description
This PR improves settings layout hierarchy, implements edge-to-edge rendering, and other general improvements.

Key highlights include:
- **Edge-to-Edge Display**: Enabled full edge-to-edge rendering to make system bars transparent and content draw behind them (#35).
- **Settings & Theme Groups**: Grouped general/appearance settings with similar tiles and optimized initial app launch theme.
- **Visual Contrast**: Added a red error tint to the "Delete All Journals" action button to alert users to destructive operations (#41).
- **Timeline Journal tile Refinements**: Hidden the "Untitled" title label for entries with no title, keeping list items clean and maintaining consistent item heights (#44).
- **Timeline Map Refinements**: Improved layout, moved attributions, fixed reloading indicator and colors.

**resolves #44**
**resolves #41**
**resolves #35**
