### PR TITLE
feat: export as markdown

### DIFF
--- a/app/src/main/java/com/denser/june/presentation/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/SettingsAction.kt
@@ -22,6 +22,7 @@ sealed interface SettingsAction {
     data object ResetBackup: SettingsAction
     data class OnRestoreJournals(val path: String): SettingsAction
     data class OnExportJournals(val includeMedia: Boolean = true) : SettingsAction
+    data class OnExportMarkdown(val includeMedia: Boolean = true) : SettingsAction
     data class OnAppLockToggle(val enabled: Boolean) : SettingsAction
     data class UpdateLockType(val type: LockType) : SettingsAction
     data class UpdatePinHash(val hash: String?) : SettingsAction

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/SettingsState.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/SettingsState.kt
@@ -17,6 +17,7 @@ data class SettingsState(
     val appTheme: AppTheme = AppTheme(),
     val deleteButtonEnabled: Boolean = true,
     val exportState: ExportState = ExportState.Idle,
+    val exportMarkdownState: ExportState = ExportState.Idle,
     val restoreState: RestoreState = RestoreState.Idle,
     val isAppLockEnabled: Boolean = false,
     val lockType: LockType = LockType.BIOMETRIC,

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/SettingsVM.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/SettingsVM.kt
@@ -117,6 +117,14 @@ class SettingsVM(
                     }
                 }
 
+                is SettingsAction.OnExportMarkdown -> {
+                    _localState.update { it.copy(exportMarkdownState = ExportState.Exporting) }
+                    val result = exportRepo.exportAsMarkdown(includeMedia = action.includeMedia)
+                    _localState.update {
+                        it.copy(exportMarkdownState = if (result != null) ExportState.ExportReady(result) else ExportState.Error)
+                    }
+                }
+
                 is SettingsAction.OnRestoreJournals -> {
                     _localState.update { it.copy(restoreState = RestoreState.Restoring) }
                     when (val res = restoreRepo.restoreData(action.path)) {
@@ -134,7 +142,8 @@ class SettingsVM(
                 SettingsAction.ResetBackup -> _localState.update {
                     it.copy(
                         restoreState = RestoreState.Idle,
-                        exportState = ExportState.Idle
+                        exportState = ExportState.Idle,
+                        exportMarkdownState = ExportState.Idle
                     )
                 }
                 is SettingsAction.OnSeedColorChange -> themePrefs.updateSeedColor(action.color)

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/components/ExportBottomSheet.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/components/ExportBottomSheet.kt
@@ -1,0 +1,168 @@
+package com.denser.june.presentation.screens.settings.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.denser.june.core.R
+import com.denser.june.presentation.components.JuneFloatingAction
+import com.denser.june.presentation.components.JuneFloatingActionBar
+
+enum class ExportFormat {
+    JSON, MARKDOWN
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportBottomSheet(
+    onDismiss: () -> Unit,
+    onExport: (format: ExportFormat, includeMedia: Boolean) -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var exportFormat by remember { mutableStateOf(ExportFormat.JSON) }
+    var includeMedia by remember { mutableStateOf(true) }
+
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        dragHandle = null
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp, bottom = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(36.dp)
+                        .height(4.dp)
+                        .background(
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            CircleShape
+                        )
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Export Data",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Text(
+                text = "Select format and options for exporting your journal entries:",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Format",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                SettingsItem(
+                    title = "JSON (Backup)",
+                    subtitle = "Full database backup. Best for restoring data.",
+                    leadingContent = {
+                        RadioButton(
+                            selected = exportFormat == ExportFormat.JSON,
+                            onClick = { exportFormat = ExportFormat.JSON }
+                        )
+                    },
+                    containerColor = if (exportFormat == ExportFormat.JSON) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                    },
+                    onClick = { exportFormat = ExportFormat.JSON }
+                )
+
+                SettingsItem(
+                    title = "Markdown",
+                    subtitle = "Plain text files. Ideal for offline reading and editing.",
+                    leadingContent = {
+                        RadioButton(
+                            selected = exportFormat == ExportFormat.MARKDOWN,
+                            onClick = { exportFormat = ExportFormat.MARKDOWN }
+                        )
+                    },
+                    containerColor = if (exportFormat == ExportFormat.MARKDOWN) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                    },
+                    onClick = { exportFormat = ExportFormat.MARKDOWN }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Include Media",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Switch(
+                    checked = includeMedia,
+                    onCheckedChange = { includeMedia = it }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = if (includeMedia) "Export size might be large. Photos & videos will be included." else "Photos & videos will not be saved. Faster and smaller.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            JuneFloatingActionBar(
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            ) {
+                JuneFloatingAction(
+                    onClick = onDismiss,
+                    label = "Cancel",
+                    icon = { Icon(painterResource(R.drawable.close_24px), contentDescription = null) },
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                JuneFloatingAction(
+                    onClick = {
+                        onDismiss()
+                        onExport(exportFormat, includeMedia)
+                    },
+                    label = "Export",
+                    icon = { Icon(painterResource(R.drawable.check_24px), contentDescription = null) }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/denser/june/presentation/screens/settings/screens/BackupScreen.kt
+++ b/app/src/main/java/com/denser/june/presentation/screens/settings/screens/BackupScreen.kt
@@ -10,13 +10,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.denser.june.core.domain.backup.ExportState
@@ -33,6 +31,8 @@ import com.denser.june.core.domain.backup.RestoreFailedException
 import com.denser.june.presentation.screens.settings.SettingsVM
 import com.denser.june.presentation.screens.settings.components.SettingSection
 import com.denser.june.presentation.screens.settings.components.SettingsItem
+import com.denser.june.presentation.screens.settings.components.ExportBottomSheet
+import com.denser.june.presentation.screens.settings.components.ExportFormat
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -47,8 +47,6 @@ fun BackupScreen() {
 
     var showExportDialog by remember { mutableStateOf(false) }
     var showRestoreWarning by remember { mutableStateOf<String?>(null) }
-
-    var includeMedia by remember { mutableStateOf(true) }
 
     val saveLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/zip")
@@ -70,6 +68,26 @@ fun BackupScreen() {
         }
     }
 
+    val saveMarkdownLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/zip")
+    ) { uri ->
+        uri?.let { targetUri ->
+            if (state.exportMarkdownState is ExportState.ExportReady) {
+                try {
+                    val tempFile = state.exportMarkdownState.file
+                    context.contentResolver.openOutputStream(targetUri)?.use { output ->
+                        tempFile.inputStream().use { input -> input.copyTo(output) }
+                    }
+                    Toast.makeText(context, "Markdown export saved successfully", Toast.LENGTH_SHORT).show()
+                } catch (e: Exception) {
+                    Toast.makeText(context, "Failed to save file", Toast.LENGTH_SHORT).show()
+                } finally {
+                    onAction(SettingsAction.ResetBackup)
+                }
+            }
+        }
+    }
+
     val restoreLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
@@ -82,6 +100,13 @@ fun BackupScreen() {
         if (state.exportState is ExportState.ExportReady) {
             val fileName = "June_Backup_${System.currentTimeMillis()}.zip"
             saveLauncher.launch(fileName)
+        }
+    }
+
+    LaunchedEffect(state.exportMarkdownState) {
+        if (state.exportMarkdownState is ExportState.ExportReady) {
+            val fileName = "June_Markdown_Export_${System.currentTimeMillis()}.zip"
+            saveMarkdownLauncher.launch(fileName)
         }
     }
 
@@ -161,22 +186,23 @@ fun BackupScreen() {
                         }
                     ) {
                         Spacer(modifier = Modifier.height(12.dp))
+                        val isExporting = state.exportState is ExportState.Exporting || state.exportMarkdownState is ExportState.Exporting
                         Button(
                             onClick = {
-                                if (state.exportState !is ExportState.Exporting) {
+                                if (!isExporting) {
                                     showExportDialog = true
                                 }
                             },
                             modifier = Modifier.fillMaxWidth(),
-                            enabled = state.exportState !is ExportState.Exporting
+                            enabled = !isExporting
                         ) {
-                            if (state.exportState is ExportState.Exporting) {
+                            if (isExporting) {
                                 CircularWavyProgressIndicator(
                                     modifier = Modifier.size(20.dp),
                                     color = MaterialTheme.colorScheme.onPrimary,
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
-                                Text("Creating Backup...")
+                                Text("Exporting...")
                             } else {
                                 Icon(
                                     painterResource(R.drawable.save_24px),
@@ -184,7 +210,7 @@ fun BackupScreen() {
                                     Modifier.size(20.dp)
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
-                                Text("Create Backup")
+                                Text("Start Export")
                             }
                         }
                     }
@@ -237,50 +263,13 @@ fun BackupScreen() {
     }
 
     if (showExportDialog) {
-        JuneDialog(
-            onDismissRequest = { showExportDialog = false },
-            title = "Create Backup?",
-            icon = R.drawable.upload_24px,
-            confirmButton = {
-                Button(
-                    onClick = {
-                        showExportDialog = false
-                        onAction(SettingsAction.OnExportJournals(includeMedia))
-                    }
-                ) { Text("Create") }
-            },
-            dismissButton = {
-                OutlinedButton(onClick = { showExportDialog = false }) { Text("Cancel") }
-            },
-            text = {
-                Column {
-                    Text("This will create a ZIP file containing your journal entries.")
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = "Include Media",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Medium
-                        )
-                        Switch(
-                            checked = includeMedia,
-                            onCheckedChange = { includeMedia = it }
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    Text(
-                        text = if (includeMedia) "Backup size might be large. Photos & videos will be included." else "Photos & videos will not be saved. Faster and smaller.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+        ExportBottomSheet(
+            onDismiss = { showExportDialog = false },
+            onExport = { format, includeMedia ->
+                if (format == ExportFormat.JSON) {
+                    onAction(SettingsAction.OnExportJournals(includeMedia))
+                } else {
+                    onAction(SettingsAction.OnExportMarkdown(includeMedia))
                 }
             }
         )

--- a/core/src/main/java/com/denser/june/core/data/backup/ExportImpl.kt
+++ b/core/src/main/java/com/denser/june/core/data/backup/ExportImpl.kt
@@ -16,6 +16,9 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 class ExportImpl(
     private val journalRepo: JournalRepository,
@@ -101,6 +104,136 @@ class ExportImpl(
             backupFile
         } catch (e: Exception) {
             AppLogger.e(AppLogger.Category.BACKUP, "ExportImpl", "Export failed with exception", e)
+            null
+        }
+    }
+
+    override suspend fun exportAsMarkdown(includeMedia: Boolean): File? = withContext(Dispatchers.IO) {
+        return@withContext try {
+            AppLogger.d(AppLogger.Category.BACKUP, "ExportImpl", "Starting markdown export. Include media: $includeMedia")
+            val journals = journalRepo.getAllJournals()
+
+            AppLogger.d(AppLogger.Category.BACKUP, "ExportImpl", "Found ${journals.size} journals to export as markdown")
+
+            val mediaDir = File(context.filesDir, "journal_media")
+            val cleanedJournals = journals.map { journal ->
+                val cleanedImages = journal.images.map { path ->
+                    val file = File(path)
+                    File(mediaDir, file.name).absolutePath
+                }
+                journal.copy(images = cleanedImages)
+            }
+
+            val backupFile = File(context.cacheDir, "JuneMarkdownExport_${System.currentTimeMillis()}.zip")
+            val zipOutputStream = ZipOutputStream(BufferedOutputStream(FileOutputStream(backupFile)))
+
+            zipOutputStream.use { zos ->
+                val yamlDateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                    .withZone(ZoneId.systemDefault())
+
+                cleanedJournals.forEach { journal ->
+                    val sb = StringBuilder()
+                    sb.append("---\n")
+                    sb.append("id: ${journal.id}\n")
+                    sb.append("title: \"${journal.title.replace("\"", "\\\"")}\"\n")
+                    journal.emoji?.let { sb.append("emoji: \"${it.replace("\"", "\\\"")}\"\n") }
+
+                    val readableCreatedAt = yamlDateFormatter.format(Instant.ofEpochMilli(journal.createdAt))
+                    val readableUpdatedAt = journal.updatedAt?.let { yamlDateFormatter.format(Instant.ofEpochMilli(it)) }
+                    val readableDateTime = yamlDateFormatter.format(Instant.ofEpochMilli(journal.dateTime))
+
+                    sb.append("createdAt: \"$readableCreatedAt\"\n")
+                    readableUpdatedAt?.let { sb.append("updatedAt: \"$it\"\n") }
+                    sb.append("dateTime: \"$readableDateTime\"\n")
+                    sb.append("isBookmarked: ${journal.isBookmarked}\n")
+                    sb.append("isArchived: ${journal.isArchived}\n")
+                    if (journal.tags.isNotEmpty()) {
+                        sb.append("tags:\n")
+                        journal.tags.forEach { tag ->
+                            sb.append("  - \"${tag.replace("\"", "\\\"")}\"\n")
+                        }
+                    }
+                    journal.location?.let { loc ->
+                        sb.append("location:\n")
+                        sb.append("  latitude: ${loc.latitude}\n")
+                        sb.append("  longitude: ${loc.longitude}\n")
+                        loc.address?.let { sb.append("  address: \"${it.replace("\"", "\\\"")}\"\n") }
+                        loc.name?.let { sb.append("  name: \"${it.replace("\"", "\\\"")}\"\n") }
+                        loc.locality?.let { sb.append("  locality: \"${it.replace("\"", "\\\"")}\"\n") }
+                    }
+                    val song = journal.songDetails
+                    if (song != null) {
+                        sb.append("song:\n")
+                        sb.append("  title: \"${song.title.replace("\"", "\\\"")}\"\n")
+                        sb.append("  artistName: \"${song.artistName.replace("\"", "\\\"")}\"\n")
+                        song.thumbnailUrl?.let { sb.append("  thumbnailUrl: \"$it\"\n") }
+                        song.previewUrl?.let { sb.append("  previewUrl: \"$it\"\n") }
+                        song.previewUrlProvider?.let { sb.append("  previewUrlProvider: \"$it\"\n") }
+                    }
+                    sb.append("---\n\n")
+
+                    sb.append("# ${journal.title}\n\n")
+                    sb.append(journal.content)
+
+                    if (journal.images.isNotEmpty()) {
+                        sb.append("\n\n## Media\n")
+                        journal.images.forEach { imagePath ->
+                            val file = File(imagePath)
+                            sb.append("![Media](../media/${journal.id}/${file.name})\n")
+                        }
+                    }
+
+                    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                        .withZone(ZoneId.systemDefault())
+                    val formattedDate = formatter.format(Instant.ofEpochMilli(journal.dateTime))
+
+                    val sanitizedTitle = journal.title.replace("[\\\\/:*?\"<>|\\s]+".toRegex(), "_").trim()
+                    val fileName = if (sanitizedTitle.isNotEmpty()) {
+                        "${formattedDate}_${sanitizedTitle}_${journal.id}.md"
+                    } else {
+                        "${formattedDate}_${journal.id}.md"
+                    }
+                    val journalEntry = ZipEntry("journals/$fileName")
+                    zos.putNextEntry(journalEntry)
+                    zos.write(sb.toString().toByteArray())
+                    zos.closeEntry()
+                }
+
+                if (includeMedia) {
+                    val processedFileNames = mutableSetOf<Pair<String, String>>()
+                    var packedMediaCount = 0
+
+                    cleanedJournals.forEach { journal ->
+                        journal.images.forEach { absolutePath ->
+                            val file = File(absolutePath)
+                            if (file.exists() && processedFileNames.add(journal.id to file.name)) {
+                                try {
+                                    val mediaEntry = ZipEntry("media/${journal.id}/${file.name}")
+                                    zos.putNextEntry(mediaEntry)
+
+                                    FileInputStream(file).use { fis ->
+                                        fis.copyTo(zos)
+                                    }
+                                    zos.closeEntry()
+                                    packedMediaCount++
+                                } catch (e: Exception) {
+                                    AppLogger.e(AppLogger.Category.BACKUP, "ExportImpl", "Failed to pack media file: ${file.name}", e)
+                                }
+                            }
+                        }
+                    }
+                    AppLogger.d(AppLogger.Category.BACKUP, "ExportImpl", "Packed $packedMediaCount media files for markdown export")
+                }
+            }
+
+            AppLogger.d(
+                AppLogger.Category.BACKUP,
+                "ExportImpl",
+                "Markdown export completed successfully. Created zip: ${backupFile.name} (size: ${backupFile.length()} bytes)"
+            )
+            backupFile
+        } catch (e: Exception) {
+            AppLogger.e(AppLogger.Category.BACKUP, "ExportImpl", "Markdown export failed with exception", e)
             null
         }
     }

--- a/core/src/main/java/com/denser/june/core/domain/backup/BackupRepos.kt
+++ b/core/src/main/java/com/denser/june/core/domain/backup/BackupRepos.kt
@@ -4,6 +4,7 @@ import java.io.File
 
 interface ExportRepo {
     suspend fun exportData(includeMedia: Boolean = true): File?
+    suspend fun exportAsMarkdown(includeMedia: Boolean = true): File?
 }
 
 interface RestoreRepo {


### PR DESCRIPTION
## Description
This PR introduces the feature to export journal entries as Markdown files (.md), packaged inside a ZIP archive along with their media attachments.

Key highlights include:
- **Markdown Export**: Generates `.md` files with YAML metadata headers and relative image links, sorting them chronologically in the output.
- **Unified Export Configs**: Added format options directly inside the existing "Export Data" modal to easily select between JSON and Markdown formats.

**resolves #33**
